### PR TITLE
[#171410497] Accept mentorship request API endpoint

### DIFF
--- a/server/controllers/mentors.js
+++ b/server/controllers/mentors.js
@@ -1,0 +1,60 @@
+/* eslint-disable consistent-return */
+import moment from 'moment';
+import { isMentor } from '../helpers/check-user-type';
+import { codes, messages } from '../utils/messages-codes';
+import sessions from '../data/sessions';
+import validate from '../helpers/validate-input';
+
+const acceptMentorship = (req, res) => {
+  const { sessionId } = req.params;
+  const { user } = req;
+  const { error, value } = validate.validateMentorResponse(req.body);
+
+  // Send an error if mentor's input does not meet requirements
+  if (error)
+    res
+      .status(codes.badRequest)
+      .json({ status: res.statusCode, error: error.message });
+
+  // Check if the user accessing this route is a mentor
+  if (!isMentor(user))
+    return res.status(codes.unauthorized).json({
+      status: res.statusCode,
+      error: messages.accessDeniedToRegularUsers
+    });
+
+  // Retrieve the session to be updated
+  const session = sessions.find(s => s.id === parseInt(sessionId, 10));
+  if (!session)
+    return res
+      .status(codes.notFound)
+      .json({ status: res.statusCode, error: messages.sessionNotFound });
+
+  // Deny access to the session, if the session retrieved does not belong to the signed in mentor
+  if (user.id !== session.mentorId)
+    return res
+      .status(codes.unauthorized)
+      .json({ status: res.statusCode, error: messages.sessionNotYours });
+
+  const respondedOn = moment().format('LLL');
+
+  // Update session and send response
+  return res.status(codes.okay).json({
+    status: codes.okay,
+    message: messages.success,
+    data: {
+      id: sessionId,
+      mentorId: user.id,
+      menteeId: session.menteeId,
+      menteeEmail: session.menteeEmail,
+      title: session.title,
+      questions: session.questions,
+      status: 'accepted',
+      createdOn: session.createdOn,
+      response: value.response,
+      respondedOn
+    }
+  });
+};
+
+export default acceptMentorship;

--- a/server/data/sessions.js
+++ b/server/data/sessions.js
@@ -1,3 +1,14 @@
-const sessions = [];
+const sessions = [
+  {
+    id: 1,
+    mentorId: 2,
+    menteeId: 1,
+    menteeEmail: 'carljenkinson@gmail.com',
+    title: 'My first session',
+    questions: 'I have a few questions',
+    status: 'pending',
+    createdOn: 'February 29, 2020 5:30 PM'
+  }
+];
 
 export default sessions;

--- a/server/data/users.js
+++ b/server/data/users.js
@@ -24,6 +24,19 @@ const users = [
     expertise: 'construction',
     is_admin: false,
     is_mentor: true
+  },
+  {
+    id: 3,
+    first_name: 'Craig',
+    last_name: 'David',
+    email: 'craigdavid@gmail.com',
+    password: '$2b$10$wZ7WbSGj9uNO5TS4VHxdp.D2sSThPRbcsHVWqumcwRgjMleRVVRIK',
+    address: 'Las Vegas',
+    bio: 'Craig has a bio',
+    occupation: 'Musician',
+    expertise: 'Music',
+    is_admin: false,
+    is_mentor: true
   }
 ];
 

--- a/server/helpers/check-user-type.js
+++ b/server/helpers/check-user-type.js
@@ -1,0 +1,9 @@
+export const isMentor = data => {
+  if (data.is_mentor) return true;
+  return false;
+};
+
+export const isAdmin = data => {
+  if (data.is_admin) return true;
+  return false;
+};

--- a/server/helpers/validate-input.js
+++ b/server/helpers/validate-input.js
@@ -56,6 +56,14 @@ const validate = {
     });
 
     return schema.validate(data);
+  },
+
+  validateMentorResponse: data => {
+    const schema = Joi.object({
+      response: Joi.string().required()
+    });
+
+    return schema.validate(data);
   }
 };
 

--- a/server/routes/main-route.js
+++ b/server/routes/main-route.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import userRouter from './users-routes';
+import mentorRouter from './mentors-routes';
 
 const router = express.Router();
 
 router.use('/api/v1', userRouter);
+router.use('/api/v1', mentorRouter);
 
 export default router;

--- a/server/routes/mentors-routes.js
+++ b/server/routes/mentors-routes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import acceptMentorship from '../controllers/mentors';
+import authoriseUser from '../middlewares/authorisation';
+
+const mentorRouter = express.Router();
+
+mentorRouter.patch(
+  '/sessions/:sessionId/accept',
+  authoriseUser,
+  acceptMentorship
+);
+
+export default mentorRouter;

--- a/server/tests/mentor-tests.js
+++ b/server/tests/mentor-tests.js
@@ -1,0 +1,160 @@
+/* eslint-disable consistent-return */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import { codes, messages } from '../utils/messages-codes';
+
+const { should } = chai;
+
+should();
+chai.use(chaiHttp);
+
+/* global describe, it */
+
+describe('Update mentorship session', () => {
+  const mentorToken = generateToken({
+    id: 2,
+    first_name: 'Ola',
+    last_name: 'fiona',
+    email: 'olafiona@gmail.com',
+    password: '$2b$10$kFjxy2DAFvutTJnYAaKj.eMPGapPWfViyZeQPRJplYEYhidC6hTT6',
+    address: 'Lagos',
+    bio: 'Ola has a bio',
+    occupation: 'Real estate developer',
+    expertise: 'construction',
+    is_admin: false,
+    is_mentor: true
+  });
+
+  const user = generateToken({
+    id: 1,
+    first_name: 'Carl',
+    last_name: 'Jenkinson',
+    email: 'carljenkinson@gmail.com',
+    password: '$2b$10$sla5Xu1lca4Vo5cMXriet.9cfEAjjCHGZOHDR0K1KtQ7tbN6Xs90G',
+    address: 'New York',
+    bio: 'Carl has a bio',
+    occupation: 'Software developer',
+    expertise: 'software development',
+    is_admin: false,
+    is_mentor: false
+  });
+
+  const wrongMentor = generateToken({
+    id: 3,
+    first_name: 'Craig',
+    last_name: 'David',
+    email: 'craigdavid@gmail.com',
+    password: '$2b$10$wZ7WbSGj9uNO5TS4VHxdp.D2sSThPRbcsHVWqumcwRgjMleRVVRIK',
+    address: 'Las Vegas',
+    bio: 'Craig has a bio',
+    occupation: 'Musician',
+    expertise: 'Music',
+    is_admin: false,
+    is_mentor: true
+  });
+
+  it('should return status 201 and an object with "status", "message" and "data" as properties', done => {
+    chai
+      .request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('Authorization', mentorToken)
+      .send({
+        response: "Mentor's response is here!"
+      })
+      .end((err, res) => {
+        if (err) return done(err);
+
+        res.body.should.be.a('object');
+        res.body.should.include.keys(['status', 'message', 'data']);
+        res.body.status.should.be.a('number');
+        res.body.status.should.equal(codes.okay);
+        res.body.message.should.be.a('string');
+        res.body.message.should.equal(messages.success);
+        res.body.data.should.be.a('object');
+        res.body.data.status.should.equal('accepted');
+      });
+    done();
+  });
+
+  it('should return status 400 if the mentor does not send a response to the mentee', done => {
+    chai
+      .request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('Authorization', mentorToken)
+      .end((err, res) => {
+        if (err) return done(err);
+
+        res.body.should.be.a('object');
+        res.body.should.include.keys(['status', 'error']);
+        res.body.status.should.be.a('number');
+        res.body.status.should.equal(codes.badRequest);
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+  it('should return status 401 if the user tries to accept a mentorship request', done => {
+    chai
+      .request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('Authorization', user)
+      .send({
+        response: "Mentor's response is here!"
+      })
+      .end((err, res) => {
+        if (err) return done(err);
+
+        res.body.should.be.a('object');
+        res.body.should.include.keys(['status', 'error']);
+        res.body.status.should.be.a('number');
+        res.body.status.should.equal(codes.unauthorized);
+        res.body.error.should.be.a('string');
+        res.body.error.should.equal(messages.accessDeniedToRegularUsers);
+      });
+    done();
+  });
+
+  it('should return status 404 if the session a mentor is trying to accept does not exist', done => {
+    chai
+      .request(app)
+      .patch('/api/v1/sessions/1000/accept')
+      .set('Authorization', mentorToken)
+      .send({
+        response: "Mentor's response is here!"
+      })
+      .end((err, res) => {
+        if (err) return done(err);
+
+        res.body.should.be.a('object');
+        res.body.should.include.keys(['status', 'error']);
+        res.body.status.should.be.a('number');
+        res.body.status.should.equal(codes.notFound);
+        res.body.error.should.be.a('string');
+        res.body.error.should.equal(messages.sessionNotFound);
+      });
+    done();
+  });
+
+  it('should return status 401 a mentor accepts a request not addressed to her/him', done => {
+    chai
+      .request(app)
+      .patch('/api/v1/sessions/1/accept')
+      .set('Authorization', wrongMentor)
+      .send({
+        response: "Mentor's response is here!"
+      })
+      .end((err, res) => {
+        if (err) return done(err);
+
+        res.body.should.be.a('object');
+        res.body.should.include.keys(['status', 'error']);
+        res.body.status.should.be.a('number');
+        res.body.status.should.equal(codes.unauthorized);
+        res.body.error.should.be.a('string');
+        res.body.error.should.equal(messages.sessionNotYours);
+      });
+    done();
+  });
+});

--- a/server/utils/messages-codes.js
+++ b/server/utils/messages-codes.js
@@ -17,7 +17,11 @@ const messages = {
   accessDeniedToMentors: 'Access to this resource is denied to all the mentors',
   success: 'Operation completed successfully',
   resourceNotFound: 'The resource you are trying to access was not found',
-  noMentor: 'The mentor you are sending a request to does not exist'
+  noMentor: 'The mentor you are sending a request to does not exist',
+  accessDeniedToRegularUsers:
+    'Access to this resource is denied to regular users',
+  sessionNotFound: 'The session you are trying to access was not found',
+  sessionNotYours: 'Access denied! This session belongs to another mentor'
 };
 
 export { codes, messages };


### PR DESCRIPTION
# What does this PR do?

It creates an API endpoint that allows mentors to accept mentorship requests sent by users

# Description of tasks to be completed

- Write tests for the `PATCH /sessions/:sessionId/accept` endpoint
- Create a controller for that endpoint and mount it on a router
- Ensure all the tests are passing 

# How should this be manually tested?

- Clone this repository
- Run `npm install` in your terminal to install all the dependencies and `npm test` to run tests
- 22 test cases should pass

# What are the relevant pivotal tracker stories?

#171410497